### PR TITLE
jwt-cpp: test_package needs cmake generator

### DIFF
--- a/recipes/jwt-cpp/all/conanfile.py
+++ b/recipes/jwt-cpp/all/conanfile.py
@@ -1,6 +1,6 @@
 from conans import ConanFile, tools
-
 import os
+
 
 class JwtCppConan(ConanFile):
     name = "jwt-cpp"
@@ -26,7 +26,7 @@ class JwtCppConan(ConanFile):
         os.rename(extracted_dir, self._source_subfolder)
 
     def package(self):
-        header_dir = self._source_subfolder + "/include/jwt-cpp/"
+        header_dir = os.path.join(self._source_subfolder, "include", "jwt-cpp/")
         self.copy("jwt.h", dst="include", src=header_dir, keep_path=False)
         self.copy("base.h", dst="include", src=header_dir, keep_path=False)
         self.copy("LICENSE", dst="licenses", src=self._source_subfolder)

--- a/recipes/jwt-cpp/all/test_package/CMakeLists.txt
+++ b/recipes/jwt-cpp/all/test_package/CMakeLists.txt
@@ -1,7 +1,8 @@
 cmake_minimum_required(VERSION 2.8.12)
 project(PackageTest CXX)
 
-set(CMAKE_VERBOSE_MAKEFILE TRUE)
+include("${CMAKE_BINARY_DIR}/conanbuildinfo.cmake")
+conan_basic_setup()
 
 find_package(jwt-cpp REQUIRED)
 

--- a/recipes/jwt-cpp/all/test_package/conanfile.py
+++ b/recipes/jwt-cpp/all/test_package/conanfile.py
@@ -2,9 +2,10 @@ from conans import ConanFile, CMake, tools
 
 import os
 
+
 class JsonCppTestConan(ConanFile):
     settings = "os", "compiler", "build_type", "arch"
-    generators = "cmake_find_package"
+    generators = "cmake", "cmake_find_package"
 
     @property
     def _is_multi_configuration(self):
@@ -18,8 +19,5 @@ class JsonCppTestConan(ConanFile):
 
     def test(self):
         if not tools.cross_building(self.settings):
-            bin_path = "example"
-            if self._is_multi_configuration:
-                bin_path = os.path.join(str(self.settings.build_type), bin_path)
-            self.output.info(bin_path)
+            bin_path = os.path.join("bin", "example")
             self.run(bin_path, run_environment=True)


### PR DESCRIPTION
You needed to add the `cmake` generator to the test_package and call `conan_basic_setup`.
This will set the output paths to a standard location.