### PR TITLE
improve file matching

### DIFF
--- a/.github/actions/pr_changed_files/action.yml
+++ b/.github/actions/pr_changed_files/action.yml
@@ -18,6 +18,8 @@ runs:
   using: "composite"
   steps:
     - uses: actions/setup-python@v4
+      with:
+        python-version: '3.10' 
     - name: Get changed files
       id: changed-files
       shell: python
@@ -28,11 +30,18 @@ runs:
         import subprocess
         import fnmatch
         import os
-
+        from pathlib import Path
+        patterns = [Path(p).parts for p in '''${{ inputs.files }}'''.splitlines()]
         res = subprocess.run(["gh", "api", "/repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files", "--paginate"], capture_output=True, check=True)
-        files = json.loads(res.stdout)
-        files = [f["filename"] for f in files]
-        files = [f for f in files if fnmatch.fnmatch(f, '''${{ inputs.files }}'''.strip())]
+        files = []
+        for f in json.loads(res.stdout):
+          filename = Path(f["filename"]).parts
+          for pattern in patterns:
+            if len(pattern) != len(filename):
+              continue
+            if all(fnmatch.fnmatch(filename[i], pattern[i]) for i in range(len(pattern))):
+              files.append(f["filename"])
+              break
         with open(os.getenv("GITHUB_OUTPUT"), "a") as output_file:
             output_file.write(f"any_changed={'true' if files else 'false'}\n")
             output_file.write(f"all_changed_files={' '.join(files)}\n")


### PR DESCRIPTION
python's fnmatch treats * as any character any number oftime, including /. This is not coherent with bash, which excludes / from *. The fix is to split the pattern and filenames by / and call fnmatch on each part.