### PR TITLE
openvc: 4.x bump libwebp

### DIFF
--- a/recipes/opencv/4.x/conanfile.py
+++ b/recipes/opencv/4.x/conanfile.py
@@ -207,7 +207,7 @@ class OpenCVConan(ConanFile):
         if self.options.with_ipp == "intel-ipp":
             self.requires("intel-ipp/2020")
         if self.options.with_webp:
-            self.requires("libwebp/1.2.4")
+            self.requires("libwebp/1.3.0")
         if self.options.get_safe("contrib_freetype"):
             self.requires("freetype/2.12.1")
             self.requires("harfbuzz/6.0.0")


### PR DESCRIPTION
Specify library name and version:  **lib/1.0**

Version conflict while trying to build this one
```
Graph root
    cli
Requirements
    imath/3.1.6#7f6b123c01e44d29f5170f2141083e44 - Downloaded (conancenter)
    jasper/4.0.0#478d874438e50163be99725c8603281a - Downloaded (conancenter)
    jbig/20160605#2d29fa02aacd76902e0d2cbbc24631ef - Downloaded (conancenter)
    libdeflate/1.17#71f492ef993b45d9b961b36fb85e801f - Downloaded (conancenter)
    libjpeg/9e#68269859e4325ddc3f995d1fd3fc9187 - Downloaded (conancenter)
    libpng/1.6.39#deca555b0890e584fc895ba756e83c06 - Downloaded (conancenter)
    libtiff/4.4.0#e6d8942022c89a22dfbe1a9b77289c7e - Downloaded (conancenter)
    opencv/4.5.5#107c7183c36c63faeb1512659ccd6c70 - Cache
    openexr/3.1.5#88ba2322e127ebe5635fcbfdff4928d2 - Downloaded (conancenter)
    xz_utils/5.4.0#186e94237b66f785e4ea095f2f621a56 - Downloaded (conancenter)
    zlib/1.2.13#13c96f538b52e1600c40b88994de240f - Downloaded (conancenter)
    zstd/1.5.4#15ac0bc440f89247276d78ea4fdf8b14 - Downloaded (conancenter)
ERROR: Version conflict: libtiff/4.4.0->libwebp/1.3.0, opencv/4.5.5->libwebp/1.2.4.

```

---

- [ ] I've read the [contributing guidelines](https://github.com/conan-io/conan-center-index/blob/master/CONTRIBUTING.md).
- [ ] I've used a [recent](https://github.com/conan-io/conan/releases/latest) Conan client version close to the [currently deployed](https://github.com/conan-io/conan-center-index/blob/master/.c3i/config_v1.yml#L6).
- [ ] I've tried at least one configuration locally with the [conan-center hook](https://github.com/conan-io/hooks.git) activated.
